### PR TITLE
Add permalink/title to index

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,6 +3,8 @@
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 
 layout: page
+title: Home
+permalink: /
 ---
 
 # Welcome to the tpm2-software community page.


### PR DESCRIPTION
The index should have a title (otherwise it is displayed in the menu as Welcome to the tpm2-software community page and a suitable permalink.

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>