### PR TITLE
Add TPM-JS reference

### DIFF
--- a/_posts/2020-05-04-TPM-JS.md
+++ b/_posts/2020-05-04-TPM-JS.md
@@ -1,0 +1,10 @@
+# TPM-JS
+
+The TPM-JS project[1] allows to experiment with a software TPM in the
+browser using the TPM2 TSS and the IBM software TPM simulator.
+
+The tutorial guides through essential TPM functionality accompanied by
+hands-on examples with the simulator.
+
+
+[1] https://google.github.io/tpm-js

--- a/software.md
+++ b/software.md
@@ -24,6 +24,7 @@ permalink: /software/
 - [LVFS / fwupd](https://fwupd.org/): [Post1](https://blogs.gnome.org/hughsie/2018/12/14/firmware-attestation/), [Post2](https://blogs.gnome.org/hughsie/2019/04/10/using-a-client-certificate-to-set-the-attestation-checksum/)
 - [ESAPI Rust Wrapper](https://crates.io/crates/tss-esapi) [Docs](https://docs.rs/tss-esapi/1.0.1/tss_esapi/)
 - [tpm2-pytss](https://github.com/tpm2-software/tpm2-pytss) [![PyPI version](https://img.shields.io/pypi/v/tpm2-pytss.svg)](https://pypi.org/project/tpm2-pytss)
+- [TPM-JS](https://google.github.io/tpm-js/)
 
 # Projects requiring TPM 2.0 support
 - OpenVPN


### PR DESCRIPTION
TPM-JS allows to experiment with a software TPM in the browser.
This commit adds a reference both in the tutorial and software
section.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>