### PR TITLE
Add TPM-JS reference

### DIFF
--- a/externalresources.md
+++ b/externalresources.md
@@ -24,6 +24,9 @@ permalink: /external/
 # Teaching
 - [Introduction To Trusted Computing by Ariel Segall](http://opensecuritytraining.info/IntroToTrustedComputing.html) [Videos](https://www.youtube.com/playlist?list=PLUFkSN0XLZ-kBgdLhorJD6BR66D5kGoUV)
 
+# Tutorials
+- [Interative Tutorial](https://google.github.io/tpm-js/)
+
 # Books
 - Trusted Computing Platforms: TPM2.0 in Context by Graeme Proudler, Liqun Chen, et al, 2016
 - A Practical Guide to TPM 2.0: Using the Trusted Platform Module in the New Age of Security by Will Arthur and David Challener, 2015

--- a/software.md
+++ b/software.md
@@ -24,6 +24,7 @@ permalink: /software/
 - [LVFS / fwupd](https://fwupd.org/): [Post1](https://blogs.gnome.org/hughsie/2018/12/14/firmware-attestation/), [Post2](https://blogs.gnome.org/hughsie/2019/04/10/using-a-client-certificate-to-set-the-attestation-checksum/)
 - [ESAPI Rust Wrapper](https://crates.io/crates/tss-esapi) [Docs](https://docs.rs/tss-esapi/1.0.1/tss_esapi/)
 - [tpm2-pytss](https://github.com/tpm2-software/tpm2-pytss) [![PyPI version](https://img.shields.io/pypi/v/tpm2-pytss.svg)](https://pypi.org/project/tpm2-pytss)
+- [TPM-JS](https://google.github.io/tpm-js/)
 
 # Projects requiring TPM 2.0 support
 - OpenVPN


### PR DESCRIPTION
TPM-JS allows to experiment with a software TPM in the browser.
This commit adds a reference both in the external and software
section.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>