### PR TITLE
modify enc.disk size as 20M

### DIFF
--- a/_posts/2020-04-13-Disk-Encryption.md
+++ b/_posts/2020-04-13-Disk-Encryption.md
@@ -175,7 +175,7 @@ provided as a password just in time (default) and or specified as key file
 managing LUKS volumes.<br>
 
 Let's setup a new LUKS volume with a simple passphrase as key protector:<br>
-12. `dd if=/dev/zero of=enc.disk bs=1M count=10`<br>
+12. `dd if=/dev/zero of=enc.disk bs=1M count=20`<br>
 13. `dd if=/dev/urandom of=disk.key bs=1 count=32`<br>
 14. `loopdevice=$(losetup -f) && sudo losetup $loopdevice enc.disk`<br>
 15. `sudo cryptsetup luksFormat --key-file=disk.key $loopdevice`<br>


### PR DESCRIPTION
I follow the code on Tutorials of Disk Encryption Apr 13, 2020, and got some problem for  luksChangeKey on enc.disk by step 3. It will show the enc.disk do not have enough size.
I try to use 20M as enc.disk size, and it works possible.

```bash
# 1. Let’s setup a new LUKS volume with a simple passphrase as key protector:
dd if=/dev/zero of=enc.disk bs=1M count=10
dd if=/dev/urandom of=disk.key bs=1 count=32
loopdevice=$(losetup -f) && sudo losetup $loopdevice enc.disk
sudo cryptsetup luksFormat --key-file=disk.key $loopdevice

# 2. Let’s start with creating and persisting a sealing object and sealing a random byte sequence as the disk key.

tpm2_createprimary -Q -C o -c prim.ctx
dd if=/dev/urandom bs=1 count=32 status=none | tpm2_create -Q -g sha256 -u seal.pub -r seal.priv -i- -C prim.ctx
tpm2_load -Q -C prim.ctx -u seal.pub -r seal.priv -n seal.name -c seal.ctx
tpm2_evictcontrol -C o -c seal.ctx 0x81010001

# 3. Now lets change the authentication from previously created disk.key to the new sealed secret and after that shred the disk.key since it’s no longer useful:

tpm2_unseal -Q -c 0x81010001 | sudo cryptsetup luksChangeKey enc.disk --key-file disk.key

```